### PR TITLE
Fixed parsing of json maps

### DIFF
--- a/spyc.yaml
+++ b/spyc.yaml
@@ -150,7 +150,7 @@ morelesskey: "<value>"
 array_of_zero: [0]
 sophisticated_array_of_zero: {rx: {tx: [0]} }
 key_value_str_json_map: {"rx": {"tx": ["fx", "sx"]}, "ab": {"cd":"de"} }
-key_value_str_json_list: [{"rx": {"tx": ["fx", "sx"]}}, {"ab": {"cd":"de"} }]
+key_value_str_json_list: [{"rx": {"tx": ["fx", "sx"]}}, {"ab": {"cd":"de"}}]
 
 switches:
   - { row: 0, col: 0, func: {tx: [0, 1]} }

--- a/spyc.yaml
+++ b/spyc.yaml
@@ -149,6 +149,8 @@ morelesskey: "<value>"
 
 array_of_zero: [0]
 sophisticated_array_of_zero: {rx: {tx: [0]} }
+key_value_str_json_map: {"rx": {"tx": ["fx", "sx"]}, "ab": {"cd":"de"} }
+key_value_str_json_list: [{"rx": {"tx": ["fx", "sx"]}}, {"ab": {"cd":"de"} }]
 
 switches:
   - { row: 0, col: 0, func: {tx: [0, 1]} }

--- a/src/Spyc.php
+++ b/src/Spyc.php
@@ -1063,10 +1063,16 @@ class Spyc {
         $key     = trim(array_shift($explode));
         $value   = trim(implode(': ', $explode));
         $this->checkKeysInValue($value);
+		// Other methods currently don't parse valid json maps or arrays of maps correctly
+        if ( str_starts_with( $value, '[{' ) || str_starts_with( $value, '{"' ) ) {
+          $value = json_decode( preg_replace( '/^.*?:\s*/', '', $line ), true );
+        }
       }
       // Set the type of the value.  Int, string, etc
-      $value = $this->_toType($value);
-      if ($key === '0') $key = '__!YAMLZero';
+      if ( ! is_array( $value ) ) {
+         $value = $this->_toType($value);
+         if ($key === '0') $key = '__!YAMLZero';
+      }
       $array[$key] = $value;
     } else {
       $array = array ($line);

--- a/src/Spyc.php
+++ b/src/Spyc.php
@@ -1065,7 +1065,12 @@ class Spyc {
         $this->checkKeysInValue($value);
       // Other methods currently don't parse valid json maps or arrays of maps correctly
         if ( str_starts_with( $value, '[{' ) || str_starts_with( $value, '{"' ) ) {
-          $value = json_decode( preg_replace( '/^.*?:\s*/', '', $line ), true );
+          $decoded = json_decode( preg_replace( '/^.*?:\s*/', '', $line ), true );
+          if ($decoded !== null || (json_last_error() === JSON_ERROR_NONE && $decoded === null)) {
+            // Accept null as valid JSON value, but only if no error occurred
+            $value = $decoded;
+          }
+          // Otherwise, leave $value as-is (fallback to original string)
         }
       }
       // Set the type of the value.  Int, string, etc

--- a/src/Spyc.php
+++ b/src/Spyc.php
@@ -1070,8 +1070,8 @@ class Spyc {
       }
       // Set the type of the value.  Int, string, etc
       if ( ! is_array( $value ) ) {
-         $value = $this->_toType($value);
-         if ($key === '0') $key = '__!YAMLZero';
+        $value = $this->_toType($value);
+        if ($key === '0') $key = '__!YAMLZero';
       }
       $array[$key] = $value;
     } else {

--- a/src/Spyc.php
+++ b/src/Spyc.php
@@ -1063,7 +1063,7 @@ class Spyc {
         $key     = trim(array_shift($explode));
         $value   = trim(implode(': ', $explode));
         $this->checkKeysInValue($value);
-		// Other methods currently don't parse valid json maps or arrays of maps correctly
+      // Other methods currently don't parse valid json maps or arrays of maps correctly
         if ( str_starts_with( $value, '[{' ) || str_starts_with( $value, '{"' ) ) {
           $value = json_decode( preg_replace( '/^.*?:\s*/', '', $line ), true );
         }

--- a/src/Spyc.php
+++ b/src/Spyc.php
@@ -1064,13 +1064,17 @@ class Spyc {
         $value   = trim(implode(': ', $explode));
         $this->checkKeysInValue($value);
       // Other methods currently don't parse valid json maps or arrays of maps correctly
-        if ( str_starts_with( $value, '[{' ) || str_starts_with( $value, '{"' ) ) {
-          $decoded = json_decode( preg_replace( '/^.*?:\s*/', '', $line ), true );
-          if ($decoded !== null || (json_last_error() === JSON_ERROR_NONE && $decoded === null)) {
-            // Accept null as valid JSON value, but only if no error occurred
+        // The default inline parser (_toType) does not correctly handle complex JSON objects.
+        // Attempt to parse as JSON first for values that look like potential JSON.
+        $first_char = isset($value[0]) ? $value[0] : '';
+        if ($first_char === '{' || $first_char === '[') {
+          $decoded = json_decode($value, true);
+          // If the value is valid JSON, use the decoded array.
+          // This correctly handles valid JSON 'null' as well.
+          if (json_last_error() === JSON_ERROR_NONE) {
             $value = $decoded;
           }
-          // Otherwise, leave $value as-is (fallback to original string)
+          // Otherwise, leave $value as a string for the legacy parser to handle.
         }
       }
       // Set the type of the value.  Int, string, etc


### PR DESCRIPTION
Valid YAML such as the following is not correctly parsed by the Spyc fork used in wp-cli. If you validate the following with other YAML validators such as yamllint.com, it is returned as valid Yaml. 
```
key: {"json_key":"json_value", "json_key2": "json_value2"}
```
This should be represented in PHP as:
```array (
  'key' =>
  array (
    'json_key' => 'json_value',
    'json_key2' => 'json_value2',
  ),
)
```
 
However, when running through the Spyc.php implementation, the following is returned:
```
array (
  'key' =>
  array (
    0 => 'json_key":"json_value',
    1 => 'json_key2": "json_value2',
  ),
)
```
This can be tested by running one of the example scripts
```
cd examples
php yaml-load.php
```
I have added two additional tests in the `spyc.yaml` file to test this issue. If you run the example `yaml-load.php` script you will see that they are handled correctly and all of the existing examples are unchanged. 

