### PR TITLE
Add missing namespace to global functions

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -10,6 +10,8 @@
    * @package Spyc
    */
 
+use Mustangostang\Spyc;
+  
 if (!function_exists('spyc_load')) {
   /**
    * Parses YAML to array.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -11,7 +11,6 @@
    */
 
 use Mustangostang\Spyc;
-  
 if (!function_exists('spyc_load')) {
   /**
    * Parses YAML to array.


### PR DESCRIPTION
@schlessera includes/functions.php is always executed.
