### PR TITLE
Do not pass `null` to `trim()`

### DIFF
--- a/src/Spyc.php
+++ b/src/Spyc.php
@@ -297,7 +297,7 @@ class Spyc {
     if (self::isTranslationWord($value)) {
       $value = $this->_doLiteralBlock($value, $indent);
     }
-    if (trim ($value) != $value)
+    if (trim ($value === null ? '' : $value) != $value)
        $value = $this->_doLiteralBlock($value,$indent);
 
     if (is_bool($value)) {

--- a/src/Spyc.php
+++ b/src/Spyc.php
@@ -297,7 +297,7 @@ class Spyc {
     if (self::isTranslationWord($value)) {
       $value = $this->_doLiteralBlock($value, $indent);
     }
-    if (trim ($value === null ? '' : $value) != $value)
+    if (trim($value ?? '') != $value)
        $value = $this->_doLiteralBlock($value,$indent);
 
     if (is_bool($value)) {


### PR DESCRIPTION
Noticed a deprecation warning while running some wp-cli tests locally on PHP 8.5